### PR TITLE
Possibilidade de passar um timezone pro formatter

### DIFF
--- a/tests/formatters/json/test_extended_json_formatter.py
+++ b/tests/formatters/json/test_extended_json_formatter.py
@@ -1,6 +1,8 @@
 import json
 import unittest
 from unittest.mock import patch
+from datetime import timezone, timedelta
+
 from aiologger.formatters.json import ExtendedJsonFormatter, \
     LOG_LEVEL_FIELDNAME, LINE_NUMBER_FIELDNAME
 from aiologger.loggers.json import LogRecord
@@ -8,7 +10,7 @@ from aiologger.loggers.json import LogRecord
 from freezegun import freeze_time
 
 
-@freeze_time('2006-06-06T06:06:06.666666')
+@freeze_time('2006-06-06T06:06:06.666666', tz_offset=3)
 class ExtendedJsonFormatterTests(unittest.TestCase):
     def setUp(self):
         self.formatter = ExtendedJsonFormatter()
@@ -37,13 +39,69 @@ class ExtendedJsonFormatterTests(unittest.TestCase):
         formatter = ExtendedJsonFormatter(exclude_fields=(LOG_LEVEL_FIELDNAME,))
         self.assertNotIn(LOG_LEVEL_FIELDNAME, formatter.log_fields)
 
-    @freeze_time('2006-06-06T06:06:06.666666')
+    @freeze_time('2006-06-06T06:06:06.666666', tz_offset=3)
     def test_formatter_fields_for_record_with_default_fields(self):
         result = dict(self.formatter.formatter_fields_for_record(self.record))
         self.assertEqual(
             result,
             {
                 'logged_at': '2006-06-06T06:06:06.666666',
+                'line_number': 42,
+                'function': 'xablaufunc',
+                'level': 'WARNING',
+                'file_path': '/aiologger/tests/formatters/test_json_formatter.py'
+            }
+        )
+
+    @freeze_time('2018-06-16T10:16:00.742', tz_offset=3)
+    def test_formatter_with_tz_info_utc(self):
+        """
+        Check that, if tz is not None, log messages must have timezone info
+        """
+        formatter = ExtendedJsonFormatter(tz=timezone.utc)
+        result = dict(formatter.formatter_fields_for_record(self.record))
+        self.assertEqual(
+            result,
+            {
+                'logged_at': '2018-06-16T10:16:00.742000+0000',
+                'line_number': 42,
+                'function': 'xablaufunc',
+                'level': 'WARNING',
+                'file_path': '/aiologger/tests/formatters/test_json_formatter.py'
+            }
+        )
+
+    @freeze_time('2018-06-16T16:20:00.742', tz_offset=0)
+    def test_formatter_with_tz_info_america_sao_paulo_from_utc(self):
+        """
+        Current time is UTC and we want logs to be generated on America/Sao_Paulo (-3)
+        """
+        tz_america = timezone(timedelta(hours=-3))
+        formatter = ExtendedJsonFormatter(tz=tz_america)
+        result = dict(formatter.formatter_fields_for_record(self.record))
+        self.assertEqual(
+            result,
+            {
+                'logged_at': '2018-06-16T13:20:00.742000-0300',
+                'line_number': 42,
+                'function': 'xablaufunc',
+                'level': 'WARNING',
+                'file_path': '/aiologger/tests/formatters/test_json_formatter.py'
+            }
+        )
+
+    @freeze_time('2018-06-16T15:20:00.742', tz_offset=-7)
+    def test_formatter_with_tz_info_other_zone(self):
+        """
+        Current time is NOT UTC (is -7) and we want logs to be generate in America/Sao_Paulo (-3)
+        """
+        tz_america = timezone(timedelta(hours=-3))
+        formatter = ExtendedJsonFormatter(tz=tz_america)
+        result = dict(formatter.formatter_fields_for_record(self.record))
+        self.assertEqual(
+            result,
+            {
+                'logged_at': '2018-06-16T05:20:00.742000-0300',
                 'line_number': 42,
                 'function': 'xablaufunc',
                 'level': 'WARNING',

--- a/tests/loggers/test_json_logger.py
+++ b/tests/loggers/test_json_logger.py
@@ -2,7 +2,7 @@ import asyncio
 import json
 import inspect
 import os
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Tuple
 from unittest.mock import Mock, patch
 
@@ -80,9 +80,9 @@ class JsonLoggerTests(asynctest.TestCase):
 
         self.assertEqual(json_log['msg'], message)
 
-    @freeze_time("2017-03-31 04:20:00")
+    @freeze_time("2017-03-31 04:20:00", tz_offset=3)
     async def test_it_logs_current_log_time(self):
-        now = datetime.now().strftime(DATETIME_FORMAT)
+        now = datetime.now(tz=timezone.utc).astimezone().strftime(DATETIME_FORMAT)
 
         await self.logger.error("Batemos tambores, eles panela.")
 


### PR DESCRIPTION
Encontrei um problema que ainda não seri como resolver.

Apesar do freezegun conseguir congelar uma data específica, não consegui fazer com que ele congelasse meu timezone atual, ou seja, os métodos do `datetime` que olham meu timezone local continuam me vendo como `tz=-3`. Por isso tem `tz_offset=+3` em todos os testes que não passam `tz` pro formatter.

Isso significa também que os testes vão quebrar quando rodados em um PC com timezone diferente de `-3`.

Talvez possamos "calcular" o tz atual e usá-lo nos testes que não repassarm `tz`. (vou até fazer esse teste).

Mexi por enquando apenas no formatter, afinal ainda precisamos definir se essa implementação é OK. Se for, aí mexo no Logger para repassar o `tz`.

@diogommartins 